### PR TITLE
🤖 Scrape via Playwright + adapt to redesigned Buyers Guide

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
       # Note that this will also check if there are changes AND skeet them to Bsky
       - name: Build and run
         run: pnpm start

--- a/buyers-guide.json
+++ b/buyers-guide.json
@@ -1,5 +1,61 @@
 [
   {
+    "category": "iphone",
+    "buyStatus": "neutral",
+    "productId": "iPhone-Air",
+    "productName": "iPhone Air",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/iphone_air_400.png"
+  },
+  {
+    "category": "iphone",
+    "buyStatus": "caution",
+    "productId": "iPhone-17-Pro",
+    "productName": "iPhone 17 Pro",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/iphone_17_pro_360.png"
+  },
+  {
+    "category": "iphone",
+    "buyStatus": "neutral",
+    "productId": "iPhone-17",
+    "productName": "iPhone 17",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/iphone_17_360.png"
+  },
+  {
+    "category": "iphone",
+    "buyStatus": "buyNow",
+    "productId": "iPhone-17e",
+    "productName": "iPhone 17e",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/iphone-17e-360.png"
+  },
+  {
+    "category": "ipad",
+    "buyStatus": "neutral",
+    "productId": "iPad-Pro",
+    "productName": "iPad Pro",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/ipad-pro-13-350.png"
+  },
+  {
+    "category": "ipad",
+    "buyStatus": "buyNow",
+    "productId": "iPad-Air",
+    "productName": "iPad Air",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/ipad-air-243.png"
+  },
+  {
+    "category": "ipad",
+    "buyStatus": "DontBuy",
+    "productId": "iPad_Mini",
+    "productName": "iPad Mini",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/ipad_mini_buyers_200.png"
+  },
+  {
+    "category": "ipad",
+    "buyStatus": "DontBuy",
+    "productId": "iPad",
+    "productName": "iPad",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/ipad-2022-300.png"
+  },
+  {
     "category": "mac",
     "buyStatus": "buyNow",
     "productId": "MacBookNeo",
@@ -47,5 +103,89 @@
     "productId": "Mac_Pro",
     "productName": "Mac Pro",
     "productImageURL": "https://images.macrumors.com/images-new/buyers-products/mac_pro_2019_416.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "caution",
+    "productId": "Apple_Watch",
+    "productName": "Apple Watch",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/watch_11_300.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "buyNow",
+    "productId": "Apple_Watch_SE",
+    "productName": "Apple Watch SE",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/watch_se3_300.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "neutral",
+    "productId": "Apple_Watch_Ultra",
+    "productName": "Apple Watch Ultra",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/watch_ultra_3_300.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "caution",
+    "productId": "AirPods",
+    "productName": "AirPods",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/airpods_4_320.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "neutral",
+    "productId": "AirPods-Pro",
+    "productName": "AirPods Pro",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/airpods_pro_3_480.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "buyNow",
+    "productId": "AirPods-Max",
+    "productName": "AirPods Max",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/airpods_max_310.png"
+  },
+  {
+    "category": "wearables",
+    "buyStatus": "neutral",
+    "productId": "AppleVisionPro",
+    "productName": "Vision Pro",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/vision-pro-400.png"
+  },
+  {
+    "category": "homeaccessories",
+    "buyStatus": "buyNow",
+    "productId": "Displays",
+    "productName": "Displays",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/studio-display-600.png"
+  },
+  {
+    "category": "homeaccessories",
+    "buyStatus": "buyNow",
+    "productId": "AirTag",
+    "productName": "AirTag",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/airtag-400.png"
+  },
+  {
+    "category": "homeaccessories",
+    "buyStatus": "caution",
+    "productId": "HomePod",
+    "productName": "HomePod",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/homepod-2023-300-trans.png"
+  },
+  {
+    "category": "homeaccessories",
+    "buyStatus": "DontBuy",
+    "productId": "Homepod-Mini",
+    "productName": "HomePod Mini",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/homepod_mini_buyers_300.png"
+  },
+  {
+    "category": "homeaccessories",
+    "buyStatus": "DontBuy",
+    "productId": "Apple_TV",
+    "productName": "Apple TV",
+    "productImageURL": "https://images.macrumors.com/images-new/buyers-products/apple-tv-4k-300.png"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   },
   "dependencies": {
     "@atproto/api": "^0.14.10",
-    "axios": "^1.8.4",
     "cheerio": "0.22.0",
     "deep-equal": "^2.2.3",
     "dotenv": "^16.4.7",
     "p-throttle": "^7.0.0",
+    "playwright": "^1.60.0",
     "string-length": "^6.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@atproto/api':
         specifier: ^0.14.10
         version: 0.14.10
-      axios:
-        specifier: ^1.8.4
-        version: 1.8.4
       cheerio:
         specifier: 0.22.0
         version: 0.22.0
@@ -26,6 +23,9 @@ importers:
       p-throttle:
         specifier: ^7.0.0
         version: 7.0.0
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       string-length:
         specifier: ^6.0.0
         version: 6.0.0
@@ -296,9 +296,6 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -309,9 +306,6 @@ packages:
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
-
-  axios@1.8.4:
-    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -384,10 +378,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -455,10 +445,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -744,25 +730,17 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
-    engines: {node: '>= 6'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1132,14 +1110,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1282,6 +1252,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -1328,9 +1308,6 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2008,8 +1985,6 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  asynckit@0.4.0: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -2017,14 +1992,6 @@ snapshots:
   await-lock@2.2.2: {}
 
   axe-core@4.10.3: {}
-
-  axios@1.8.4:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axobject-query@4.1.0: {}
 
@@ -2111,10 +2078,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   concat-map@0.0.1: {}
 
   core-js-compat@3.41.0:
@@ -2200,8 +2163,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  delayed-stream@1.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -2681,20 +2642,14 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.9: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.2:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
-
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3065,12 +3020,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -3215,6 +3164,14 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -3252,8 +3209,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/bsky-bot/index.ts
+++ b/src/bsky-bot/index.ts
@@ -21,10 +21,11 @@ const buyStatusToReadable: Record<BuyStatus, string> = {
 };
 
 const categoryToEmojiMap: Record<Category, string> = {
-  [Category.IOs]: '📱',
+  [Category.IPhone]: '📱',
+  [Category.IPad]: '📱',
   [Category.Mac]: '💻',
-  [Category.Music]: '🎧',
-  [Category.Other]: '⌚',
+  [Category.Wearables]: '⌚',
+  [Category.HomeAccessories]: '🏠',
 };
 
 const getEmojiAndReadable = (status: BuyStatus): [string, string] => [buyStatusToEmojiMap[status], buyStatusToReadable[status]];

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,8 +1,9 @@
 export enum Category {
-  IOs = 'ios',
+  IPhone = 'iphone',
+  IPad = 'ipad',
   Mac = 'mac',
-  Music = 'music',
-  Other = 'other',
+  Wearables = 'wearables',
+  HomeAccessories = 'homeaccessories',
 }
 
 export enum BuyStatus {

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import axios from 'axios';
+import { chromium } from 'playwright';
 import cheerio from 'cheerio';
 import deepEqual from 'deep-equal';
 import postUpdateToBlueSky from '../bsky-bot/index.js';
@@ -28,15 +28,64 @@ export type UpdatedEntry = {
   nextStatus: BuyStatus;
 };
 
+const READY_SELECTOR = '#pane-iphone ul'; // Real-content signal: present once Cloudflare clears.
+const NAV_TIMEOUT_MS = 30_000;
+const CLEAR_TIMEOUT_MS = 45_000; // Budget for the Cloudflare challenge to clear.
+
 /**
- * Takes any web URL, fetches it and parses it with cheerio.
- * Assumes HTML is returned from the endpoint.
+ * Loads a URL in a real (headless) browser so Cloudflare's managed challenge
+ * can run its JS and grant a `cf_clearance` cookie, then parses the resulting
+ * HTML with cheerio. A bare HTTP GET only ever sees the "Just a moment…"
+ * interstitial, so a browser engine is required.
+ *
+ * Throws if the challenge doesn't clear, so the run fails loudly instead of
+ * writing the interstitial page as scraped data.
  *
  * @param {string} url - The given URL
  */
 async function fetchPageAndParse(url: string): Promise<cheerio.Root> {
-  const { data } = await axios.get<string>(url);
-  return cheerio.load(data);
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      '--disable-blink-features=AutomationControlled',
+      '--no-sandbox', // Required on the GitHub Actions ubuntu runner.
+      '--disable-dev-shm-usage', // Avoid /dev/shm exhaustion crashes in CI.
+    ],
+  });
+  try {
+    const context = await browser.newContext({
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+        + '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      viewport: {
+        width: 1280,
+        height: 800,
+      },
+      locale: 'en-US',
+      timezoneId: 'America/Los_Angeles',
+    });
+    const page = await context.newPage();
+    await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAV_TIMEOUT_MS,
+    });
+    try {
+      await page.waitForSelector(READY_SELECTOR, {
+        state: 'attached',
+        timeout: CLEAR_TIMEOUT_MS,
+      });
+    } catch {
+      const title = await page.title().catch(() => '');
+      throw new Error(
+        `Cloudflare challenge did not clear in ${CLEAR_TIMEOUT_MS}ms `
+        + `(last title: "${title}"). Likely a datacenter-IP block. Aborting so `
+        + 'no stale data is committed.',
+      );
+    }
+    return cheerio.load(await page.content());
+  } finally {
+    await browser.close();
+  }
 }
 
 const URL = 'https://buyersguide.macrumors.com/';
@@ -91,7 +140,15 @@ async function comparePrevious(updatedEntries: Entry[]): Promise<UpdatedEntry[] 
 
 const updatedEntries = (await comparePrevious(entries)) ?? [];
 
-if (updatedEntries.length > 0) {
+// eslint-disable-next-line n/no-process-env -- Opt-out switch for priming a fresh baseline.
+const skipSkeet = (process.env.SKIP_SKEET ?? '') !== '';
+
+if (updatedEntries.length > 0 && skipSkeet) {
+  //  Priming a fresh baseline (e.g. after a site redesign): record the data
+  //  without skeeting the backlog of differences.
+  // eslint-disable-next-line no-console
+  console.log(`🙊 SKIP_SKEET set — recording ${updatedEntries.length} change(s) without posting.`);
+} else if (updatedEntries.length > 0) {
   //  We can start them all concurrently because they are throttled anyway.
   await Promise.all(updatedEntries.map(postUpdateToBlueSky));
   // eslint-disable-next-line no-console


### PR DESCRIPTION
## Why

The `Scrape & skeet` Action has failed ~4×/day since Mar 27. Two separate breakages, both on `buyersguide.macrumors.com`:

1. **Cloudflare managed challenge.** A bare `axios.get` only ever received the "Just a moment…" interstitial (HTTP 403), so `pnpm start` exited 1. (The Node 20 deprecation warnings in the logs were a red herring — already addressed separately on `main`.)
2. **Site redesign.** Categories changed from `ios/mac/music/other` to `iphone/ipad/mac/wearables/homeaccessories`. The `ul → li.<color>` structure is unchanged, so only the schema needed updating.

## What

- **Playwright headless Chromium** replaces axios in `fetchPageAndParse`. It runs the challenge JS to earn `cf_clearance`, then hands the real HTML to cheerio (parsing untouched). Throws if the challenge doesn't clear, so a block fails the run loudly instead of committing the interstitial as data.
- `Category` enum + Bluesky `categoryToEmojiMap` updated for the new categories (iPad 📱, Home/Accessories 🏠).
- `SKIP_SKEET` opt-out added; used to **prime a fresh `buyers-guide.json` baseline** so the first successful run doesn't skeet ~2 months of accumulated diffs.
- CI: cache + install the Chromium binary.

## Verification

- Local: clears CF, parses 27 entries across all 5 categories, re-run = no changes.
- **CI (this branch, datacenter IP): green in 49s — Playwright cleared Cloudflare, `🌈 No changes detected!`, nothing committed.** Run: https://github.com/himynameisdave/macrumors-buyersguide-bsky/actions/runs/26467963384

## Caveat

GitHub Actions datacenter IPs are penalized by Cloudflare; clearing is proven now but may be intermittent. The loud-throw design means any future block surfaces as a red Action, not silent stale data.